### PR TITLE
Fix auth, pass info into Dial

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,37 @@
+package nassh
+
+import "context"
+
+type contextKey string
+
+const (
+	ctxUserID       contextKey = "user-id"
+	ctxLoginSession contextKey = "login-session"
+	ctxSSHSession   contextKey = "ssh-session"
+	ctxRemoteAddr   contextKey = "remote-addr"
+)
+
+// UserID returns the unique user identity from the given context
+func UserID(ctx context.Context) (string, bool) {
+	u, ok := ctx.Value(ctxUserID).(string)
+	return u, ok
+}
+
+// LoginSessionID returns the identifier of the login session from the given
+// context
+func LoginSessionID(ctx context.Context) (string, bool) {
+	l, ok := ctx.Value(ctxLoginSession).(string)
+	return l, ok
+}
+
+// SSHSessionID returns the identifier of the relay session
+func SSHSessionID(ctx context.Context) (string, bool) {
+	u, ok := ctx.Value(ctxSSHSession).(string)
+	return u, ok
+}
+
+// RemoteAddr returns the remote address of the caller
+func RemoteAddr(ctx context.Context) (string, bool) {
+	r, ok := ctx.Value(ctxRemoteAddr).(string)
+	return r, ok
+}

--- a/example_test.go
+++ b/example_test.go
@@ -2,19 +2,31 @@ package nassh
 
 import (
 	"net/http"
-
-	"github.com/sirupsen/logrus"
 )
 
 func ExampleRelay() {
 	// Bare minimum server
-	r := Relay{
-		Logger: logrus.New(),
-	}
+	r := Relay{}
 
 	m := http.NewServeMux()
 
-	m.HandleFunc("/cookie", r.SimpleCookieHandler)
+	// cookie is the URL the client calls first
+	m.HandleFunc("/cookie", func(w http.ResponseWriter, req *http.Request) {
+		// this is where you'd handle your authentication flow.
+
+		// Assuming auth is done, this is the last step to continue the SSH
+		// process.
+		userID := "User from auth flow"
+		authSessID := "unique ID to track this login flow"
+
+		ext := req.URL.Query().Get("ext")
+		path := req.URL.Query().Get("path")
+		version := req.URL.Query().Get("version")
+		method := req.URL.Query().Get("method")
+
+		r.StartSession(w, req, userID, authSessID, ext, path, version, method)
+	})
+
 	m.HandleFunc("/proxy", r.ProxyHandler)
 	m.HandleFunc("/connect", r.ConnectHandler)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/lstoll/nassh-relay
 go 1.12
 
 require (
+	github.com/gorilla/securecookie v1.1.1
+	github.com/gorilla/sessions v1.1.3
 	github.com/gorilla/websocket v1.4.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.1.3 h1:uXoZdcdA5XdXF3QzuSlheVRUvjl+1rKY7zBXL68L9RU=
+github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/session.go
+++ b/session.go
@@ -3,7 +3,7 @@ package nassh
 import (
 	"bytes"
 	"encoding/binary"
-	"net"
+	"io"
 	"sync"
 	"time"
 
@@ -105,7 +105,7 @@ type clientRead struct {
 type session struct {
 	logger logrus.FieldLogger
 	// conn is the connection to the SSH server
-	conn net.Conn
+	conn io.ReadWriteCloser
 	// inactivityDuration is the duration after which, if a client has not
 	// been connected, the session will be automatically closed.
 	inactivityDuration time.Duration
@@ -122,7 +122,7 @@ type session struct {
 }
 
 // newSession creates a new session. Call Start to start reading from the server.
-func newSession(logger logrus.FieldLogger, conn net.Conn, inactivityDuration time.Duration, afterCloseFunc func()) *session {
+func newSession(logger logrus.FieldLogger, conn io.ReadWriteCloser, inactivityDuration time.Duration, afterCloseFunc func()) *session {
 	s := &session{
 		logger:             logger,
 		conn:               conn,


### PR DESCRIPTION
This implements proper auth checking, where the proxy command ensures the
cookie flow was successful

The cookie flow method was changed to make it's usage a bit clearer

More information is passed in the context, so it can be retrieved by the
dialer.